### PR TITLE
Catch AttributeError when magic has no from_file() function

### DIFF
--- a/fileinspector.py
+++ b/fileinspector.py
@@ -28,7 +28,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 import sys
 import mimetypes
@@ -106,7 +106,9 @@ def determine_type_with_magic(filename, mime=True):
 		raise ImportError("python-magic is not available. This function cannot be used")
 	try:
 		ftype = magic.from_file(filename,mime=mime)
-	except IOError:
+	# In some cases, magic doesn't have the from_file() function, which is why
+	# we also catch AttributeErrors.
+	except (IOError, AttributeError):
 		ftype = None
 
 	if type(ftype) == bytes:


### PR DESCRIPTION
This is a simple fix for an error that occurs when a `magic` exists, but has no `from_file()` function. I'm not sure when this happens, but I've experienced it myself on a Kubuntu 16.04 setup, and someone reported it [on the forum](http://forum.cogsci.nl/index.php?p=/discussion/2406/bug-with-full-factorial-design-button#latest) as well.

Could you tag it as 1.0.2 and push it to pypi and conda?
