### PR TITLE
Fix deb packaging for stdeb3

### DIFF
--- a/fileinspector.py
+++ b/fileinspector.py
@@ -28,7 +28,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__version__ = '1.0.2'
+__version__ = '1.0.3a1'
 
 import sys
 import mimetypes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [bdist_wheel]
 universal=1
 
+[sdist_dsc]
+with-python2=true
+with-python3=true

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,12 @@ You should have received a copy of the GNU General Public License
 along with fileinspector.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import sys
 from setuptools import setup
 import fileinspector
 
 setup(
-	name='python-fileinspector',
+	name='fileinspector' if 'bdist_deb' in sys.argv else 'python-fileinspector',
 	version=fileinspector.__version__,
 	description='A module to determine file mimetypes',
 	author='Daniel Schreij',

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Source=python-fileinspector
+Source=fileinspector
 Package=python-fileinspector
 Debian-version=1
-Suite=xenial
+Suite=bionic
 Copyright-File=copyright


### PR DESCRIPTION
This is a slight tweak to the packaging system for Ubuntu, using stdeb3. This now allows packaging for Python 3 and Python 2 packages. Right now the packages live in https://launchpad.net/~smathot/+archive/ubuntu/rapunzel/.